### PR TITLE
Revise README for token permissions and example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A GitHub Action that lists [GitHub Blog](https://github.blog/) entries that matc
 ## Inputs
 
 - `token` - A token with `repo` scope
+  - If using `${{ secrets.GITHUB_TOKEN }}`, ensure that the token has both read and write permissions in the repo where the workflow is running
+  - To double-check your setting, go to `https://github.com/OWNER/REPO/settings/actions`
 - `dry-run` - If `true`, the RSS feed will only be reported in the console log. If `false`, an issue will be created to list all RSS feed entries found.
 - `labels` - A multi-line list of labels to search for. E.g. including `actions` will trigger the following search; `https://github.blog/feed/?s=actions`
 - `days` - The number of days worth of posts to include in the list
@@ -20,8 +22,6 @@ A GitHub Action that lists [GitHub Blog](https://github.blog/) entries that matc
 ### Example workflow
 
 ```yml
-# .github/workflows/get-blog-entries.yml
-
 name: Get GitHub blog entries
 
 on:
@@ -32,23 +32,13 @@ jobs:
     name: Get GitHub blog RSS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Get GitHub Blog RSS
         id: get-github-blog-rss
-        uses: ./
+        uses: stebje/action-gh-blog-feed@v0.1.0
         with:
-          token: ${{ secrets.MY_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           dry-run: false
           labels: |
             'actions'
             'copilot'
-          days: 7
 ```
-
-## ToDo
-
-- [ ] Check and fix for vulnerable coding patterns
-- [ ] Use GITHUB_TOKEN for API authentication if possible
-- [ ] Add tests
-- [ ] Add CI workflow with test suite
-- [ ] Update README with updated info


### PR DESCRIPTION
Updated README to clarify token permissions and changed example workflow to use GITHUB_TOKEN.